### PR TITLE
Refactored `snapcraft.yml`

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -14,12 +14,15 @@ apps:
   cheat:
     environment: 
       CHEAT_EDITOR: nano
+      CHEAT_PATH: "$SNAP/lib/python2.7/site-packages/usr/share/cheat/"
+      PYTHONIOENCODING: 'utf-8'
     command: cheat
     plugs: [home]
     
 parts:
   cheat:
     source: https://github.com/chrisallenlane/cheat.git
+    source-branch: dev
     plugin: python
     python-version: python2
     python-packages:
@@ -28,15 +31,3 @@ parts:
       - pygments
     stage-packages: 
       - nano
-    override-build: |
-      git apply $SNAPCRAFT_STAGE/../patches/Bugfix-encoding-issue.patch
-      snapcraftctl build
-    override-prime: |
-      snapcraftctl prime
-      echo "SNAPCRAFT_PRIME: $SNAPCRAFT_PRIME"
-      echo "SNAPCRAFT_STAGE: $SNAPCRAFT_STAGE"
-      echo "SNAPCRAFT_PART_BUILD: $SNAPCRAFT_PART_BUILD"
-      echo "I am executed in: $(pwd)"
-      mkdir -p $SNAPCRAFT_PRIME/usr/share/cheat
-      cp $SNAPCRAFT_PART_BUILD/cheat/cheatsheets/* $SNAPCRAFT_PRIME/usr/share/cheat/
-


### PR DESCRIPTION
Refactored `snapcraft.yml` in an effort to build a snap that does not
exhibit issues when attempting to output UTF-8-formatted text. Relevant
changes include:

- Building off of `dev` branch rather than `master` (after merging
fixes into `dev` upstream.
- Removing override scripts
- Exporting `PYTHONIOENCODING` environment variable in the container
- Re-pathing cheatsheet path away from `/usr/share/cheat` to (what
appears to be) the correct location.

The snap now appears to behave as desired.